### PR TITLE
fix priority error

### DIFF
--- a/client.go
+++ b/client.go
@@ -205,7 +205,11 @@ func (p *aliMNSClient) Send(method Method, headers map[string]string, message in
 				xmlContent = m
 			}
 		default:
-			if bXml, e := xml.Marshal(message); e != nil {
+			messageSendRequest, ok := message.(MessageSendRequest)
+			if ok && messageSendRequest.Priority == 0 {
+				messageSendRequest.Priority = 8
+			}
+			if bXml, e := xml.Marshal(messageSendRequest); e != nil {
 				err = ERR_MARSHAL_MESSAGE_FAILED.New(errors.Params{"err": e})
 				return nil, err
 			} else {


### PR DESCRIPTION
Signed-off-by: penghuima <2992426202@qq.com>

#12 

测试代码


```go
	...
	queue = ali_mns.NewMNSQueue(queueName, client)
	msg := ali_mns.MessageSendRequest{
		MessageBody: "hello error <\"aliyun-mns-go-sdk\">"}
	ret, err := queue.SendMessage(msg) 
	if err != nil {
		fmt.Println(err)
	}
	fmt.Printf("Send succ, message id: %s, messagebody md5: %s\n", ret.MessageId, ret.MessageBodyMD5)
```

执行结果如下

```bash
Send succ, message id: EB0A77CA8076444C573E8E8B9F25xxxx, messagebody md5: 911FF56FA65DB8D984C1A502F54Dxxxx
```


