### PR TITLE
Release/2.0.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ MNS v1 官方 Go SDK,封装 smq proxy HTTP 数据面 API(队列收发消息、�
 |------|-----|
 | **名称** | aliyun-mns-go-sdk (MNS Go SDK) |
 | **语言** | Go 1.20+ |
-| **模块** | github.com/aliyun/aliyun-mns-go-sdk |
-| **版本** | 2.0.1 |
+| **模块** | github.com/aliyun/aliyun-mns-go-sdk/v2 |
+| **版本** | 2.0.2 |
 | **HTTP 库** | fasthttp (valyala/fasthttp) |
 | **认证** | aliyun/credentials-go |
 | **API 文档** | https://help.aliyun.com/zh/mns/developer-reference/ |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## 2.0.2
+- Migrate Go module path to `github.com/aliyun/aliyun-mns-go-sdk/v2` to comply with Go Modules v2+ major version suffix convention. All import paths in examples, tests, and documentation have been updated accordingly. Backward compatible for users who import via the `/v2` path.
+
 ## 2.0.1
 - Support MNS endpoint domains with a variable number of segments. `NewAliMNSClientWithConfig` no longer requires the endpoint host to have a fixed number of `.`-separated segments (previously exactly 5). The host is now derived from `net/url` `Hostname()` (with a bare-domain fallback for backward compatibility), and `accountId` is extracted from the first host label. This aligns with the Java SDK, which only validates the URI scheme and host. Backward compatible with existing endpoints.
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -21,8 +21,8 @@ Aliyun MNS Go SDK 是 MNS 在 Go 编译语言的官方 SDK
 
 ## 安装方法
 
-- 执行命令 `go get github.com/aliyun/aliyun-mns-go-sdk` 获取远程代码包
-- 在您的代码中通过 `import "github.com/aliyun/aliyun-mns-go-sdk"` 引入 MNS Go SDK
+- 执行命令 `go get github.com/aliyun/aliyun-mns-go-sdk/v2` 获取远程代码包
+- 在您的代码中通过 `import "github.com/aliyun/aliyun-mns-go-sdk/v2"` 引入 MNS Go SDK
 
 ## 快速使用
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The Aliyun MNS Go SDK is the official SDK for MNS in the Go programming language
 
 ## Installing
 
-- Run the`go get github.com/aliyun/aliyun-mns-go-sdk` command to get the remote code package.
-- Use `import "github.com/aliyun/aliyun-mns-go-sdk"` in your code to introduce MNS Go SDK package
+- Run the`go get github.com/aliyun/aliyun-mns-go-sdk/v2` command to get the remote code package.
+- Use `import "github.com/aliyun/aliyun-mns-go-sdk/v2"` in your code to introduce MNS Go SDK package
 
 ## Getting Start
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,13 +4,13 @@
 
 ## 分发形态
 
-- **产物类型**:Go module 库(`github.com/aliyun/aliyun-mns-go-sdk`),供外部客户 `import` 使用,**不产出可执行服务 / 镜像 / 端口**。
+- **产物类型**:Go module 库(`github.com/aliyun/aliyun-mns-go-sdk/v2`),供外部客户 `import` 使用,**不产出可执行服务 / 镜像 / 端口**。
 - **消费方式**:
   ```bash
-  go get github.com/aliyun/aliyun-mns-go-sdk@<version>
+  go get github.com/aliyun/aliyun-mns-go-sdk/v2@<version>
   ```
 - **分发通道**:Go module proxy(goproxy)按 module path + version 提供下载。
-- **开发源 vs 发布源**:本仓(内部 gitlab `messaging/aliyun-mns-go-sdk`)是开发主仓;对外发布通过公开镜像仓 `github.com/aliyun/aliyun-mns-go-sdk` 打版本 tag。**本仓当前不承载 release tag。**
+- **开发源 vs 发布源**:本仓(内部 gitlab `messaging/aliyun-mns-go-sdk`)是开发主仓;对外发布通过公开镜像仓 `github.com/aliyun/aliyun-mns-go-sdk` 打版本 tag(v2+ 需使用 `/v2` 后缀)。**本仓当前不承载 release tag。**
 
 ## 版本一致性(硬约束)
 

--- a/example/create_queue_example.go
+++ b/example/create_queue_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	ali_mns "github.com/aliyun/aliyun-mns-go-sdk"
+	ali_mns "github.com/aliyun/aliyun-mns-go-sdk/v2"
 	"os"
 	"time"
 )

--- a/example/open_service_example.go
+++ b/example/open_service_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/aliyun/aliyun-mns-go-sdk"
+	"github.com/aliyun/aliyun-mns-go-sdk/v2"
 	"os"
 )
 

--- a/example/queue_example.go
+++ b/example/queue_example.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/aliyun/aliyun-mns-go-sdk"
+	"github.com/aliyun/aliyun-mns-go-sdk/v2"
 	"github.com/gogap/logs"
 )
 

--- a/example/topic_example.go
+++ b/example/topic_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/aliyun/aliyun-mns-go-sdk"
+	"github.com/aliyun/aliyun-mns-go-sdk/v2"
 	"github.com/gogap/logs"
 	"os"
 	"time"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aliyun/aliyun-mns-go-sdk
+module github.com/aliyun/aliyun-mns-go-sdk/v2
 
 go 1.20
 

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"testing"
 
-	"github.com/aliyun/aliyun-mns-go-sdk"
+	"github.com/aliyun/aliyun-mns-go-sdk/v2"
 )
 
 func TestNewAliMNSClientWithConfig(t *testing.T) {

--- a/test/queue_test.go
+++ b/test/queue_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"testing"
 
-	"github.com/aliyun/aliyun-mns-go-sdk"
+	"github.com/aliyun/aliyun-mns-go-sdk/v2"
 )
 
 func createQueueTestClient() (ali_mns.MNSClient, error) {

--- a/test/topic_test.go
+++ b/test/topic_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"testing"
 
-	"github.com/aliyun/aliyun-mns-go-sdk"
+	"github.com/aliyun/aliyun-mns-go-sdk/v2"
 )
 
 func createTopicTestClient() (ali_mns.MNSClient, error) {

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package ali_mns
 
 const (
 	SdkName = "aliyun-sdk-go"
-	Version = "2.0.1"
+	Version = "2.0.2"
 )


### PR DESCRIPTION
- Migrate go.mod module path from github.com/aliyun/aliyun-mns-go-sdk to github.com/aliyun/aliyun-mns-go-sdk/v2 (Go Modules v2+ convention)
- Update all import paths in examples, tests, and documentation
- Bump version to 2.0.2